### PR TITLE
Support `ast-grep-ignore`

### DIFF
--- a/R/node.R
+++ b/R/node.R
@@ -625,10 +625,6 @@ remove_ignored_nodes <- function(nodes) {
   }
 }
 
-`%||%` <- function(x, y) {
-  if (!is.null(x) && length(x) > 0) x else y
-}
-
 #' Navigate the tree
 #'
 #' @description
@@ -910,15 +906,4 @@ node_replace_all <- function(x, ...) {
 
   class(out) <- c("astgrep_replacements", class(out))
   out
-}
-
-node_has_parent <- function(x, include_root = FALSE) {
-  check_is_rulelist_or_node(x)
-
-  res <- length(x$parent()) > 0
-
-  if (res && !include_root) {
-    res <- length(x$parent()$parent()) > 0
-  }
-  res
 }

--- a/src/rust/src/node.rs
+++ b/src/rust/src/node.rs
@@ -293,20 +293,6 @@ impl SgNode {
             .collect()
     }
 
-    // fn get_matcher(&self, config: Option<List>, kwargs: Option<List>) -> RuleCore<tree_sitter_facade_sg::Language> {
-    //     let lang = self.inner.lang();
-    //     let config = if let Some(config) = config {
-    //         config_from_dict(config)?
-    //     } else if let Some(rule) = kwargs {
-    //         config_from_rule(rule)?
-    //     } else {
-    //         return Err(extendr_api::Error::Other("rule must not be empty"));
-    //     };
-    //     let env = DeserializeEnv::new(*lang);
-    //     let matcher = config.get_matcher(env).context("cannot get matcher")?;
-    //     Ok(matcher)
-    // }
-
     /*---------- Edit  ----------*/
     fn replace(&self, text: &str) -> List {
         let byte_range = self.inner.range();
@@ -370,27 +356,6 @@ impl From<List> for Edit {
     }
 }
 
-// fn config_from_dict(dict: Option<&str>) -> Result<SerializableRuleCore> {
-//     use extendr_api::deserializer::from_robj;
-//     Ok(SerializableRuleCore {
-//         rule: dict.rule,
-//         constraints: dict.constraints,
-//         utils: dict.utils,
-//         transform: dict.transform,
-//         fix: dict.constraints,
-//     })
-// }
-
-// fn config_from_rule(dict: Option<&str>) -> Result<SerializableRuleCore> {
-//     Ok(SerializableRuleCore {
-//         rule: dict.elt(0),
-//         constraints: None,
-//         utils: None,
-//         transform: None,
-//         fix: None,
-//     })
-// }
-
 fn get_matcher_from_rule(lang: crate::language::R, rule: &str) -> RuleCore<crate::language::R> {
     let rule = crate::ser::new_rule(rule);
 
@@ -406,11 +371,7 @@ fn get_matcher_from_rule(lang: crate::language::R, rule: &str) -> RuleCore<crate
     rule_core.get_matcher(env).unwrap()
 }
 
-// Macro to generate exports.
-// This ensures exported functions are registered with R.
-// See corresponding C code in `entrypoint.c`.
 extendr_module! {
     mod node;
-    // fn ast_grep_r;
     impl SgNode;
 }

--- a/tests/tinytest/test-ignore.R
+++ b/tests/tinytest/test-ignore.R
@@ -1,0 +1,85 @@
+source("helpers.R")
+
+# one match -------------------------------
+
+src <- "
+# ast-grep-ignore
+any(duplicated(x))
+print(1)
+"
+
+root <- src |>
+  tree_new() |>
+  tree_root()
+
+expect_equal(
+  root |>
+    node_find(ast_rule(pattern = "any(duplicated($A))")) |>
+    node_text(),
+  list(rule_1 = NULL)
+)
+
+expect_equal(
+  root |>
+    node_find_all(ast_rule(pattern = "any(duplicated($A))")) |>
+    node_text_all(),
+  list(rule_1 = list())
+)
+
+# multiple matches -------------------------------
+
+src <- "
+# ast-grep-ignore
+any(duplicated(x))
+any(duplicated(foo))
+print(1)
+"
+
+root <- src |>
+  tree_new() |>
+  tree_root()
+
+expect_equal(
+  root |>
+    node_find(ast_rule(pattern = "any(duplicated($A))")) |>
+    node_text(),
+  list(rule_1 = "any(duplicated(foo))")
+)
+
+expect_equal(
+  root |>
+    node_find_all(ast_rule(pattern = "any(duplicated($A))")) |>
+    node_text_all(),
+  list(rule_1 = list(node_1 = "any(duplicated(foo))"))
+)
+
+
+# more nested pattern -------------------------------
+
+src <- "
+# ast-grep-ignore
+if (TRUE) {
+  any(duplicated(x))
+  any(duplicated(foo))
+}
+print(1)
+"
+
+root <- src |>
+  tree_new() |>
+  tree_root()
+
+# TODO: should work I guess
+# expect_equal(
+#   root |>
+#     node_find(ast_rule(pattern = "any(duplicated($A))")) |>
+#     node_text(),
+#   list(rule_1 = NULL)
+# )
+#
+# expect_equal(
+#   root |>
+#     node_find_all(ast_rule(pattern = "any(duplicated($A))")) |>
+#     node_text_all(),
+#   list(rule_1 = list())
+# )

--- a/tests/tinytest/test-ignore.R
+++ b/tests/tinytest/test-ignore.R
@@ -58,9 +58,8 @@ expect_equal(
 
 src <- "
 # ast-grep-ignore
-if (TRUE) {
-  any(duplicated(x))
-  any(duplicated(foo))
+if (any(is.na(x))) {
+  any(duplicated(y))
 }
 print(1)
 "
@@ -69,17 +68,16 @@ root <- src |>
   tree_new() |>
   tree_root()
 
-# TODO: should work I guess
-# expect_equal(
-#   root |>
-#     node_find(ast_rule(pattern = "any(duplicated($A))")) |>
-#     node_text(),
-#   list(rule_1 = NULL)
-# )
-#
-# expect_equal(
-#   root |>
-#     node_find_all(ast_rule(pattern = "any(duplicated($A))")) |>
-#     node_text_all(),
-#   list(rule_1 = list())
-# )
+expect_equal(
+  root |>
+    node_find(ast_rule(pattern = "any(is.na($A))")) |>
+    node_text(),
+  list(rule_1 = NULL)
+)
+
+expect_equal(
+  root |>
+    node_find(ast_rule(pattern = "any(duplicated($A))")) |>
+    node_text(),
+  list(rule_1 = "any(duplicated(y))")
+)


### PR DESCRIPTION
Close #10 

Need to check if calling `find_all()` instead of `find()` really affects performance


- [x] better navigate across parents 
- [x] cleanup