### PR TITLE
Enable multiple replacements for the same line 

### DIFF
--- a/src/rust/src/node.rs
+++ b/src/rust/src/node.rs
@@ -329,28 +329,33 @@ impl SgNode {
             .collect();
 
         let offset = self.inner.range().start;
-        // let mut start = 0;
 
         let old_length = old_content.chars().count();
         let mut new_length = old_length;
 
         for diff in converted {
             let mut start = diff.start_pos - offset;
-            let mut end = diff.end_pos;
+            let mut end = diff.end_pos - offset;
 
             let diff_length = new_length - old_length;
             let diff_length_i32 = (new_length - old_length) as i32;
 
             if diff_length_i32 > 0 {
-                start = start + diff_length;
-                end = end + diff_length;
+                start += diff_length;
+                end += diff_length;
             } else if diff_length_i32 < 0 {
-                start = start - diff_length;
-                end = end - diff_length;
+                rprintln!("here 2");
+                rprintln!("diff_length: {:?}", diff_length);
+                start -= diff_length;
+                rprintln!("start: {:?}", start);
+                end -= diff_length;
+                rprintln!("end: {:?}", end);
             }
 
             new_content.replace_range(start..end, &diff.inserted_text);
+            rprintln!("new_content: {:?}", new_content);
             new_length = new_content.chars().count();
+            rprintln!("new_length: {:?}", new_length);
         }
 
         new_content

--- a/src/rust/src/node.rs
+++ b/src/rust/src/node.rs
@@ -330,15 +330,44 @@ impl SgNode {
 
         let offset = self.inner.range().start;
         let mut start = 0;
+
+        let old_length = old_content.chars().count();
+        let mut new_length = old_length;
+
+        // rprintln!("offset: {:?}", offset);
+        // rprintln!("converted: {:?}", converted);
+
         for diff in converted {
-            let pos = diff.start_pos - offset;
-            // skip overlapping edits
+            let mut pos = diff.start_pos - offset;
+            let mut end_pos = diff.end_pos;
+            // rprintln!("pos: {:?}", pos);
+            // rprintln!("start: {:?}", start);
             if start > pos {
-                continue;
+                rprintln!("here");
+                let diff_length = new_length - old_length;
+                let diff_length_i32 = (new_length - old_length) as i32;
+                rprintln!("diff_length: {:?}", diff_length);
+                rprintln!("diff_length_i32: {:?}", diff_length_i32);
+
+                if diff_length_i32 > 0 {
+                    pos = pos + diff_length;
+                    end_pos = end_pos + diff_length;
+                } else if diff_length_i32 < 0 {
+                    rprintln!("here 2");
+                    pos = pos - diff_length;
+                    end_pos = end_pos - diff_length;
+                    rprintln!("pos: {:?}", pos);
+                    rprintln!("end_pos: {:?}", end_pos);
+                } else {
+                    pos = pos;
+                    end_pos = end_pos;
+                }
+                // continue;
             }
             new_content.push_str(&old_content[start..pos]);
             new_content.push_str(&diff.inserted_text);
-            start = diff.end_pos - offset;
+            start = end_pos - offset;
+            new_length = new_content.chars().count();
         }
         // add trailing statements
         new_content.push_str(&old_content[start..]);

--- a/src/rust/src/node.rs
+++ b/src/rust/src/node.rs
@@ -334,28 +334,21 @@ impl SgNode {
         let mut new_length = old_length;
 
         for diff in converted {
-            let mut start = diff.start_pos - offset;
-            let mut end = diff.end_pos - offset;
+            let mut start = (diff.start_pos - offset) as i32;
+            let mut end = (diff.end_pos - offset) as i32;
 
-            let diff_length = new_length - old_length;
-            let diff_length_i32 = (new_length - old_length) as i32;
+            let diff_length = (new_length - old_length) as i32;
 
-            if diff_length_i32 > 0 {
+            if diff_length != 0 {
                 start += diff_length;
                 end += diff_length;
-            } else if diff_length_i32 < 0 {
-                rprintln!("here 2");
-                rprintln!("diff_length: {:?}", diff_length);
-                start -= diff_length;
-                rprintln!("start: {:?}", start);
-                end -= diff_length;
-                rprintln!("end: {:?}", end);
             }
 
-            new_content.replace_range(start..end, &diff.inserted_text);
-            rprintln!("new_content: {:?}", new_content);
+            let start_usize = start as usize;
+            let end_usize = end as usize;
+
+            new_content.replace_range(start_usize..end_usize, &diff.inserted_text);
             new_length = new_content.chars().count();
-            rprintln!("new_length: {:?}", new_length);
         }
 
         new_content

--- a/src/rust/src/node.rs
+++ b/src/rust/src/node.rs
@@ -315,8 +315,8 @@ impl SgNode {
 
         edits2.sort_by_key(|edit| edit.start_pos);
 
-        let mut new_content = String::new();
         let old_content = self.text();
+        let mut new_content = old_content.clone();
         let root = &self.root;
         let conv = &root.position;
         let converted: Vec<_> = edits2
@@ -329,48 +329,30 @@ impl SgNode {
             .collect();
 
         let offset = self.inner.range().start;
-        let mut start = 0;
+        // let mut start = 0;
 
         let old_length = old_content.chars().count();
         let mut new_length = old_length;
 
-        // rprintln!("offset: {:?}", offset);
-        // rprintln!("converted: {:?}", converted);
-
         for diff in converted {
-            let mut pos = diff.start_pos - offset;
-            let mut end_pos = diff.end_pos;
-            // rprintln!("pos: {:?}", pos);
-            // rprintln!("start: {:?}", start);
-            if start > pos {
-                rprintln!("here");
-                let diff_length = new_length - old_length;
-                let diff_length_i32 = (new_length - old_length) as i32;
-                rprintln!("diff_length: {:?}", diff_length);
-                rprintln!("diff_length_i32: {:?}", diff_length_i32);
+            let mut start = diff.start_pos - offset;
+            let mut end = diff.end_pos;
 
-                if diff_length_i32 > 0 {
-                    pos = pos + diff_length;
-                    end_pos = end_pos + diff_length;
-                } else if diff_length_i32 < 0 {
-                    rprintln!("here 2");
-                    pos = pos - diff_length;
-                    end_pos = end_pos - diff_length;
-                    rprintln!("pos: {:?}", pos);
-                    rprintln!("end_pos: {:?}", end_pos);
-                } else {
-                    pos = pos;
-                    end_pos = end_pos;
-                }
-                // continue;
+            let diff_length = new_length - old_length;
+            let diff_length_i32 = (new_length - old_length) as i32;
+
+            if diff_length_i32 > 0 {
+                start = start + diff_length;
+                end = end + diff_length;
+            } else if diff_length_i32 < 0 {
+                start = start - diff_length;
+                end = end - diff_length;
             }
-            new_content.push_str(&old_content[start..pos]);
-            new_content.push_str(&diff.inserted_text);
-            start = end_pos - offset;
+
+            new_content.replace_range(start..end, &diff.inserted_text);
             new_length = new_content.chars().count();
         }
-        // add trailing statements
-        new_content.push_str(&old_content[start..]);
+
         new_content
     }
 }

--- a/tests/tinytest/_snapshots/rewrite_one_line_several_replacements.txt
+++ b/tests/tinytest/_snapshots/rewrite_one_line_several_replacements.txt
@@ -1,0 +1,2 @@
+lab <- anyNA(x)
+drat <- anyDuplicated(gsub("\\d{1,}\\w\\s+(.*)", "\\1", mpg)) > 0

--- a/tests/tinytest/test-replace.R
+++ b/tests/tinytest/test-replace.R
@@ -163,21 +163,31 @@ expect_snapshot(
   tree_rewrite(root, fixes)
 )
 
+# several replacements on the same line ---------------------------------------
 
-# TODO: this should work
-# nodes_to_replace <- root |>
-#   node_find_all(
-#     ast_rule(id = "foo", pattern = "$A = $B"),
-#     ast_rule(id = "foo2", pattern = "any(is.na($EXPR))")
-#   )
-#
-# fixes <- nodes_to_replace |>
-#   node_replace_all(
-#     foo = "~~A~~ <- ~~B~~",
-#     foo2 = "anyNA(~~EXPR~~)"
-#   )
-#
-# expect_snapshot(
-#   "rewrite_several_rules_escaped_chars",
-#   tree_rewrite(root, fixes)
-# )
+src <- r'(lab = any(is.na(x))
+drat = any(duplicated(gsub("\\d{1,}\\w\\s+(.*)", "\\1", mpg))))'
+
+root <- src |>
+  tree_new() |>
+  tree_root()
+
+nodes_to_replace <- root |>
+  node_find_all(
+    ast_rule(id = "foo", pattern = "$A = $B"),
+    ast_rule(id = "foo2", pattern = "any(duplicated($VAR))"),
+    ast_rule(id = "foo3", pattern = "any(is.na($VAR))")
+  )
+
+fixes <- nodes_to_replace |>
+  node_replace_all(
+    foo = "~~A~~ <- ~~B~~",
+    foo2 = "anyDuplicated(~~VAR~~) > 0",
+    foo3 = "anyNA(~~VAR~~)"
+  )
+
+expect_snapshot(
+  "rewrite_one_line_several_replacements",
+  tree_rewrite(root, fixes)
+)
+


### PR DESCRIPTION
Close #25

---

~Almost there, but the empty line at the beginning should be kept (but `root$text()` already doesn't show the first line break)~ This is not related to this PR: https://github.com/ast-grep/ast-grep/issues/1345

```r

src <- r'(
lab = gsub("\\s+", "", lab)
drat = any(is.na(gsub("\\d{1,}\\w\\s+(.*)", "\\1", mpg)))
)'

root <- src |>
  tree_new() |>
  tree_root()

nodes_to_replace <- root |>
  node_find_all(
    ast_rule(id = "foo", pattern = "$A = $B"),
    ast_rule(id = "foo2", pattern = "any(is.na($EXPR))")
  )

fixes <- nodes_to_replace |>
  node_replace_all(
    foo = "~~A~~ <- ~~B~~",
    foo2 = "anyNA(~~EXPR~~)"
  )

tree_rewrite(root, fixes)
```
```
lab <- gsub("\\s+", "", lab)
drat <- anyNA(gsub("\\d{1,}\\w\\s+(.*)", "\\1", mpg))

```