### PR TITLE
Find out the cause of the newline bug

### DIFF
--- a/R/tree.R
+++ b/R/tree.R
@@ -32,14 +32,8 @@ tree_new <- function(txt, file, ignore_tags = "ast-grep-ignore") {
   } else {
     raw_txt <- strsplit(txt, "\\n")[[1]]
   }
-  HAS_TRAILING_NEW_LINE <- TRUE
-  if (!grepl("\\\n$", txt)) {
-    txt <- paste0(txt, "\n")
-    HAS_TRAILING_NEW_LINE <- FALSE
-  }
   out <- SgRoot$new(txt)
   attr(out, "lines_to_ignore") <- find_lines_to_ignore(raw_txt, ignore_tags)
-  attr(out, "has_trailing_new_line") <- HAS_TRAILING_NEW_LINE
   out
 }
 
@@ -134,7 +128,6 @@ tree_root <- function(x) {
   check_is_tree(x)
   out <- x$root()
   attr(out, "lines_to_ignore") <- attr(x, "lines_to_ignore")
-  attr(out, "has_trailing_new_line") <- attr(x, "has_trailing_new_line")
   out
 }
 
@@ -208,9 +201,6 @@ tree_rewrite <- function(root, replacements) {
   # https://github.com/ast-grep/ast-grep/issues/1345
   leading_newlines <- strrep("\n", root$range()[[1]][1])
   new_txt <- paste0(leading_newlines, new_txt)
-  if (isFALSE(attributes(root)[["has_trailing_new_line"]])) {
-    new_txt <- gsub("\\\n$", "", new_txt)
-  }
   class(new_txt) <- c("astgrep_rewritten_tree", class(new_txt))
   new_txt
 }


### PR DESCRIPTION
Just a place to explore #29:

``` r
library(astgrepr)

"x = 1\nx\n\ny = 1\ny" |> 
  tree_new() |> 
  tree_root() |> 
  node_find_all(files = "C:/Users/etienne/Desktop/Divers/astgrepr/foo.yml") |> 
  node_text_all()
#> $rule_1
#> $rule_1$node_1
#> [1] "x = 1"
```

```yml
rule:
  kind: binary_operator
  all:
    - has:
        field: lhs
        kind: identifier
        pattern: $IDENT
    - precedes:
        stopBy: end
        kind: identifier
        pattern: $IDENT
```

In the python API:

```python
import ast_grep_py as sg

haspat = sg.Rule(field="left", kind="identifier", pattern="$IDENT")
insidepat = sg.Rule(
    kind="expression_statement",
    precedes=sg.Rule(
        kind="expression_statement",
        has=sg.Rule(kind="identifier", pattern="$IDENT"),
    ),
)

nodes = (
    sg.SgRoot("x = 1\nx\n\ny = 1\ny", "python")
    .root()
    .find_all(kind="assignment", all=[sg.Rule(has=haspat, inside=insidepat)])
)

for node in nodes:
    node.text()

# 'x = 1'
# 'y = 1'
```