### PR TITLE
fix install_github org values

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -54,7 +54,7 @@ install.packages("astgrepr")
 Development version (you might need to install [Rust](https://www.rust-lang.org/tools/install)):
 ```r
 # install.packages("remotes")
-remotes::install_github("etienne/astgrepr")
+remotes::install_github("etiennebacher/astgrepr")
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Development version (you might need to install
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("etienne/astgrepr")
+remotes::install_github("etiennebacher/astgrepr")
 ```
 
 ## Demo


### PR DESCRIPTION
Thanks for the great work @etiennebacher. This came about from copy-and-paste trying to debug install, leading to nothing more than something for you to keep in mind: rustup allows for installation of multiple versions. I'm not suggesting you should do anything, but just keep in mind that you might one day like or need to improve current single `rustc --version` with an iteration over `rustup toolchain list` to see whether _any_ versions do indeed satisfy, and issue message if current _default_ does not, yet another installed version would.